### PR TITLE
fix: MatchParen highlight

### DIFF
--- a/lua/sweetie/highlights/core.lua
+++ b/lua/sweetie/highlights/core.lua
@@ -56,7 +56,7 @@ core.setup = function(palette)
 
     Conceal = { fg = palette.grey },
     NonText = { fg = palette.dark_grey, bold = true },
-    MatchParen = { reverse = true },
+    MatchParen = { bg = palette.bg_hl, bold = true },
     Whitespace = { link = "NonText" },
 
     Highlight = { bg = palette.bg_alt },


### PR DESCRIPTION
Just doing reverse=true was very very confusing. I immediately got lost of where my cursor was. Here is a little fix :)