### PR TITLE
Add: windows-terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ overrides = {
   - [x] termux
   - [ ] fish shell
   - [x] florisboard
+  - [x] windows terminal
 
 ## License
 

--- a/extras/windows-terminal/Sweetie Dark.json
+++ b/extras/windows-terminal/Sweetie Dark.json
@@ -1,0 +1,25 @@
+{
+    "name": "Sweetie Dark",
+    "background": "#2a2a3e",
+    "foreground": "#fdfffd",
+    "selectionBackground": "#232331",
+    "cursorColor": "#75daff",
+
+    "black": "#232331",
+    "red": "#e87272",
+    "green": "#91f582",
+    "yellow": "#f4b47c",
+    "blue": "#75daff",
+    "purple": "#e9b5ff",
+    "cyan": "#77f8e7",
+    "white": "#fdfffd",
+
+    "brightBlack": "#7e7e7e",
+    "brightRed": "#e87272",
+    "brightGreen": "#91f582",
+    "brightYellow": "#f7e277",
+    "brightBlue": "#75daff",
+    "brightPurple": "#c8b5ff",
+    "brightCyan": "#b5e9ff",
+    "brightWhite": "#eeffee"
+}

--- a/extras/windows-terminal/Sweetie Light.json
+++ b/extras/windows-terminal/Sweetie Light.json
@@ -1,0 +1,25 @@
+{
+    "name": "Sweetie Light",
+    "background": "#dddde7",
+    "foreground": "#202023",
+    "selectionBackground": "#bbbbce",
+    "cursorColor": "#78789d",
+
+    "black": "#202023",
+    "red": "#b31919",
+    "green": "#287f0d",
+    "yellow": "#ae580e",
+    "blue": "#0c5090",
+    "purple": "#a00c79",
+    "cyan": "#47948a",
+    "white": "#fdfffd",
+
+    "brightBlack": "#78789d",
+    "brightRed": "#b31919",
+    "brightGreen": "#287f0d",
+    "brightYellow": "#957d09",
+    "brightBlue": "#0c5090",
+    "brightPurple": "#9437ff",
+    "brightCyan": "#0b658e",
+    "brightWhite": "#8989a9"
+}


### PR DESCRIPTION
I have just added windows-terminal support based of kitty support colors.

![image](https://github.com/NTBBloodbath/sweetie.nvim/assets/87276646/32ca6a11-1f68-49e9-aac5-94f6ac277c63)
![image](https://github.com/NTBBloodbath/sweetie.nvim/assets/87276646/d36b1db4-ed37-498b-b2a1-93bb1a748db2)
