### PR TITLE
Use undercurl for errors highlights

### DIFF
--- a/lua/sweetie/highlights/core.lua
+++ b/lua/sweetie/highlights/core.lua
@@ -178,10 +178,10 @@ core.setup = function(palette)
 
     --- Spelling ---
     ----------------
-    SpellBad = { sp = palette.red, underline = true },
-    SpellCap = { sp = palette.blue, underline = true },
-    SpellRare = { sp = palette.yellow, underline = true },
-    SpellLocal = { sp = palette.fg_alt, underline = true },
+    SpellBad = { sp = palette.red, undercurl = true },
+    SpellCap = { sp = palette.blue, undercurl = true },
+    SpellRare = { sp = palette.yellow, undercurl = true },
+    SpellLocal = { sp = palette.fg_alt, undercurl = true },
   }
 end
 

--- a/lua/sweetie/highlights/lsp.lua
+++ b/lua/sweetie/highlights/lsp.lua
@@ -4,10 +4,10 @@ local lsp = {}
 
 lsp.setup = function(palette)
   return {
-    MsgUnderline = { sp = palette.green, underline = true },
-    MoreMsgUnderline = { sp = palette.blue, underline = true },
-    ErrorMsgUnderline = { sp = palette.red, underline = true },
-    WarningMsgUnderline = { sp = palette.yellow, underline = true },
+    MsgUnderline = { sp = palette.green, undercurl = true },
+    MoreMsgUnderline = { sp = palette.blue, undercurl = true },
+    ErrorMsgUnderline = { sp = palette.red, undercurl = true },
+    WarningMsgUnderline = { sp = palette.yellow, undercurl = true },
 
     LspCodeLens = { fg = palette.grey },
     LspHighlight = { bg = palette.bg_alt, bold = true },


### PR DESCRIPTION
This tweaks the theme to use undercurls instead of underlines for error highlights. I believe this falls back to underlines correctly on terminals which don't support undercurl.