### PR TITLE
Alacritty dark theme - Background and foreground inverted

### DIFF
--- a/extras/alacritty/sweetie_dark.toml
+++ b/extras/alacritty/sweetie_dark.toml
@@ -1,7 +1,7 @@
 [colors]
 [colors.primary]
-foreground = "#2a2a3e"
-background = "#fdfffd"
+foreground = "#fdfffd"
+background = "#2a2a3e"
 [colors.cursor]
 cursor = "#75daff"
 [colors.normal]


### PR DESCRIPTION
Background color and foreground color were inverted in `sweetie_dark.toml`.

Alacritty with sweetie dark before fix :
![sweetie_dark_alacritty_bug](https://github.com/user-attachments/assets/a9ccff6f-db3e-4b21-84ac-da24ccd85b66)

Alacritty with sweetie dark after fix :
![sweetie_dark_alacritty_fixed](https://github.com/user-attachments/assets/f31d48ba-7200-4087-82cb-76756963fa31)